### PR TITLE
$resource not available

### DIFF
--- a/src/ride/web/rest/jsonapi/AssetJsonApiResourceAdapter.php
+++ b/src/ride/web/rest/jsonapi/AssetJsonApiResourceAdapter.php
@@ -34,6 +34,9 @@ class AssetJsonApiResourceAdapter extends EntryJsonApiResourceAdapter {
      */
     public function getResource($data, JsonApiDocument $document, $relationshipPath = null) {
         $resource = parent::getResource($data, $document, $relationshipPath);
+        if (!$resource) {
+          return null;
+        }
 
         $value = $resource->getAttribute('value');
         if ($value && !StringHelper::startsWith($value, array('http://', 'https://'))) {


### PR DESCRIPTION
When no image is set as a resource and we're trying to fetch it, the API returns a 500 error:
![screen shot 2017-03-09 at 11 19 05](https://cloud.githubusercontent.com/assets/1144162/23745892/41906a44-04ba-11e7-8abb-be9f6dfd04a2.png)

After this fix:
![screen shot 2017-03-09 at 11 17 54](https://cloud.githubusercontent.com/assets/1144162/23745910/51f7024e-04ba-11e7-8777-e42a2f8df825.png)

